### PR TITLE
Re-enables symfony cache permissions task

### DIFF
--- a/tasks/symfony/cache.rake
+++ b/tasks/symfony/cache.rake
@@ -28,6 +28,7 @@ namespace :symfony do
                 execute "sudo chown -R www-data:deploy #{release_path}/var"
                 execute "sudo chmod -R 0777 #{release_path}/var"
                 info "Cache permissions updated"
+                Rake::Task['symfony:cache:permissions'].reenable
             end
         end
     end


### PR DESCRIPTION
Re-enables symfony cache permissions task to allow it to be called more than once.