### PR TITLE
Updates excludes for core:files:downloads task

### DIFF
--- a/tasks/core/files.rake
+++ b/tasks/core/files.rake
@@ -7,7 +7,7 @@
 namespace :core do
     namespace :files do
         set :default_rsync_flags,     Array.[]('--archive', '--verbose', '--checksum', '--no-perms')
-        set :excluded_download_paths, Array.[]('video/*', 'uploads/documents/*')
+        set :excluded_download_paths, Array.[]('video/*', 'videos/*', 'uploads/documents/*', 'xml_files/*')
         set :excluded_upload_paths,   Array.[]('data/*', 'xml_files/*')
 
         # Creates a string of excludes


### PR DESCRIPTION
Adds videos/* and xml_files/* to excluded download paths for core:files:download task